### PR TITLE
fix: delete associated reviews when deleting a cafe

### DIFF
--- a/app.py
+++ b/app.py
@@ -161,10 +161,13 @@ def edit_cafe(cafe_id):
 @login_required
 def delete_cafe(cafe_id):
     cafe = Cafe.query.get_or_404(cafe_id)
+    reviews = Review.query.filter_by(cafe_id=cafe.id).all()
     if cafe.created_by != current_user.id:
         flash("You can only delete cafes that you've added.")
         return redirect(url_for("index"))
     
+    for review in reviews:
+        db.session.delete(review)
     db.session.delete(cafe)
     db.session.commit()
     flash("Cafe deleted successfully!")

--- a/app.py
+++ b/app.py
@@ -161,11 +161,11 @@ def edit_cafe(cafe_id):
 @login_required
 def delete_cafe(cafe_id):
     cafe = Cafe.query.get_or_404(cafe_id)
-    reviews = Review.query.filter_by(cafe_id=cafe.id).all()
     if cafe.created_by != current_user.id:
         flash("You can only delete cafes that you've added.")
         return redirect(url_for("index"))
     
+    reviews = Review.query.filter_by(cafe_id=cafe.id).all()
     for review in reviews:
         db.session.delete(review)
     db.session.delete(cafe)


### PR DESCRIPTION
Cafes could be deleted because the cafe id is a foreign key in the reviews table. This PR updates the delete function to delete associated reviews as well.